### PR TITLE
fix: remove `resetForm` from raw-data page `useEffect`

### DIFF
--- a/src/pages/search/rawdata/useLogic.jsx
+++ b/src/pages/search/rawdata/useLogic.jsx
@@ -395,7 +395,6 @@ const useLogic = (isExprCalls, initSearchResult = {}) => {
   useEffect(() => {
     if (selectedSpecies.value !== EMPTY_SPECIES_VALUE.value) {
       getSexesAndDevStageForSpecies();
-      resetForm(true);
     }
   }, [selectedSpecies]);
 


### PR DESCRIPTION
An unnecessary resetForm call in a useEffect trigger at page load was removing all URL params, that was causing the gene and tissue field being erased, fixes https://bgee.atlassian.net/browse/BA-911

@smoretti @jwollbrett 