### PR TITLE
fix(ssr): route SSR API calls to internal domain to avoid Cloudflare blocks

### DIFF
--- a/src/api/prod/constant.ts
+++ b/src/api/prod/constant.ts
@@ -1,8 +1,11 @@
 import axios from 'axios';
 import config from '../../config.json';
 
+// SSR goes through internal API domain to avoid Cloudflare limitations
+const baseURL = import.meta.env.SSR ? (process.env.INTERNAL_API_DOMAIN ?? config.apiDomain) : config.apiDomain;
+
 const axiosInstance = axios.create({
-  baseURL: config.apiDomain,
+  baseURL,
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
   },

--- a/src/routes/gene.$geneId.tsx
+++ b/src/routes/gene.$geneId.tsx
@@ -54,8 +54,13 @@ export async function loader({ params, request }) {
       requestUrl: request.url.replace(/^https?:\/\/.+?\//, `${config.genericDomain}/`),
     };
   } catch (error: any) {
-    // console.error('Error loading gene data:', error);
-    throw new Response(error.data?.message || error.message || 'Gene not found', { status: 404 });
+    const status = error?.response?.status ?? error?.status;
+    if (status === 404 || (typeof status === 'number' && status >= 400 && status < 500)) {
+      throw new Response(error.data?.message || error.message || 'Gene not found', { status: 404 });
+    }
+    // Handle non 404 errors (e.g. network issues, server errors)
+    console.error('Gene loader API failure:', params.geneId, status ?? '', error?.message);
+    throw new Response('Upstream error while loading gene data', { status: 502 });
   }
 }
 


### PR DESCRIPTION
SSR loaders called the public www.bgee.org/api, looping back through Cloudflare and getting intermittently rate-limited/challenged, surfacing as random 404s on gene pages. 
SSR now uses `INTERNAL_API_DOMAIN` env variable when set. 

Also map upstream failures (timeout/5xx/CF) to 502 instead of 404 in gene page

@fbastian @smoretti 